### PR TITLE
removeTail() sometimes returns nullptr.

### DIFF
--- a/cachelib/allocator/datastruct/AtomicDList.h
+++ b/cachelib/allocator/datastruct/AtomicDList.h
@@ -270,6 +270,8 @@ class AtomicDList {
 
   mutable folly::cacheline_aligned<Mutex> mtx_;
 
+  mutable std::shared_mutex head_mutex;
+  
   // head of the linked list
   std::atomic<T*> head_{nullptr};
 


### PR DESCRIPTION
removeTail() function sometimes returns nullptr.
Source code is modified to avoid that as follows.

(1)Make linkAtHead() and unlink() mutually exclusive by using readers-writer lock.
(2)Make sure to clear the item returned by removeTail.
